### PR TITLE
repro 9177

### DIFF
--- a/alternate/lib/BUILD
+++ b/alternate/lib/BUILD
@@ -1,0 +1,1 @@
+python_library()

--- a/alternate/lib/test2.py
+++ b/alternate/lib/test2.py
@@ -1,0 +1,3 @@
+def test() -> None:
+    return 3
+

--- a/pants.ini
+++ b/pants.ini
@@ -8,3 +8,9 @@ plugins: +["pantsbuild.pants.contrib.mypy==%(pants_version)s"]
 [python-setup]
 interpreter_constraints: ['CPython>=3.6']
 
+
+[source]
+source_roots: {
+    '': ('python'),
+    'alternate': ('python'),
+  }


### PR DESCRIPTION
here is a reproduction of the issue I got in https://github.com/pantsbuild/pants/issues/9177

Replacing the first source root of `""` with `"src"` fixes the problem.  

Declaring the build-root as a source root is _maybe_ a little weird but everything has worked fine until 1.22.0.

If pants wants to disallow it, it could just reject that source root when it loads the config.

In retrospect the problem is sort of obvious, sorry I didn't catch it when I reported an issue!